### PR TITLE
filters: normalise filter coeffs to 'unity' gain

### DIFF
--- a/dynamicFilters.cpp
+++ b/dynamicFilters.cpp
@@ -315,3 +315,36 @@ void audioFilter(short h[], const int &N, const int &TYPE, const int &WINDOW, co
                   break;
   }                  
 }
+
+//Additions from Graham
+// The filters come out with some attenuation - too much for my linking.
+// If we can measure the gain at the requested bandpass, then we can scale
+// the coefficients to actual 0db (neutral, no gain or attenuation) for the
+// chosen frequency, which should, ideally, be the peak of the filter.
+//
+// Gain is the root of the sum of the squares of cos and sin waves. Don't ask me for
+// the theory!!!
+float32_t getFilterGain(int16_t *coeffs, int ncoeffs, float32_t frequency, float32_t samplerate) {
+  float32_t cgain=0.0, sgain=0.0;
+  float32_t gain = 0.0;
+  float32_t f = frequency / samplerate;
+
+  for(int i=0; i<ncoeffs; i++ ) {
+    float32_t c = cos(2.0 * M_PI * f * i);
+    float32_t s = sin(2.0 * M_PI * f * i);
+
+    cgain += ((float32_t)coeffs[i]/32768.0) * c;
+    sgain += ((float32_t)coeffs[i]/32768.0) * s;
+  }
+
+  gain = (cgain*cgain) + (sgain*sgain);
+
+  //FIXME - we probably should limit the gain returned somewhere - possibly here.
+  return (sqrt(gain));
+}
+
+void normaliseCoeffs(int16_t *coeffs, int ncoeffs, float32_t multiplier) {
+  for( int i=0; i<ncoeffs; i++ ) {
+    coeffs[i] *= multiplier;
+  }
+}

--- a/dynamicFilters.h
+++ b/dynamicFilters.h
@@ -68,5 +68,8 @@ void wBlackman(double w[], const int &N);
 void wHanning(double w[], const int &N);
 void wHamming(double w[], const int &N);
 
+// Helper functions to normalise FIR coefficients for maximum gain.
+extern float32_t getFilterGain(int16_t *coeffs, int ncoeffs, float32_t frequency, float32_t samplerate);
+extern void normaliseCoeffs(int16_t *coeffs, int ncoeffs, float32_t multiplier);
 
 #endif


### PR DESCRIPTION
I've noticed that the dynamic FIR filter coefficients end up
with a lot of attenuation at the center frequency. I think it's
just a consequence of using fast dynamic filter coeff generation,
rather than the long winded and processor intense 'optimal'
calculations (if we do an online coeff calculation and inject those
coeffs into a static table then we do see good non-attenuating
performance).

This impact the processing chain - as the filters come very early
in the chain they basically reduce our 'data width' a lot, which must
hurt some of the later algorithms.

Try to 'normalise' the filters, by assessing their performance at their
chosen center frequency, and then normalising the coefficients up to
that (the nice thing about FIR coeffs is you can adjust gain just by
multiplying the coeffs, within reason of course).

And then it was found that if we take the raw gain and apply it to the
coeffs, we end up with constant low level 'white noise', probably as the
filter coeffs are pretty 'maxed out' - so, limit our gain application to
2.0, and apply it at 90% (so, 1.8x max). This does help out with our final
output 'volume' somewhat at least.

Fixes: #1

Signed-off-by: Graham Whaley <graham.whaley@gmail.com>