### PR TITLE
Decimate the audio path to improve NR functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ coding up my own.
 As an added bonus, the CW decoders tend to be better than the one built into my transceiver, and auto
 detect key speed.
 
-An expanded list of [Features can be found below](#features).
+An expanded list of [Features can be found below](#feature-list).
 
 ## Honorable mentions
 
@@ -54,7 +54,7 @@ A [history of versions](#version-history) can be found at the end of this docume
 ## Hardware
 
 The basic hardware is built around a [Teensy 4.0][9] board along with its matching
-[audio daugthercard][10]. In addition to that there is a 2x16 screen, a single LED, a rotary click
+[audio daughtercard][10]. In addition to that there is a 2x16 screen, a single LED, a rotary click
 encoder and a switch to enter reprogramming mode. That's it. Pretty simple.
 
 ![Internal view](./photos/Internals.JPG)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Honorable mentions then to:
 
 and many others.
 
+## Versions
+
+A [history of versions](#version-history) can be found at the end of this document.
+
 ## Hardware
 
 The basic hardware is built around a [Teensy 4.0][9] board along with its matching
@@ -79,14 +83,10 @@ A key feature, and a powerful feature of the audio library, is that inbetween th
 can, and do, apply other processing to the data flow, such as using the [ARM CMSIS][11] functions or
 open coding algorithms (as is done for some of the noise reduction code).
 
-Presently the whole flow runs at the native audio library sample rate of 44.1kHz. This costs us
-processing and data bandwidth overhead, but gives us a little simplicity, skipping any decimation
-and interpolation steps.  Later it may be necessary or desirable to move to a decimated datapath,
-for reasons including:
-
-- will take less processing time and data flow overheads
-- will give us better filtering (FIR filters for instance) for the same number of 'taps'
-- may improve the noise reduction, by allowing finer grained 'bins'
+From Version 1.1 the audio path is run with a decimation of 4, bringing the path down to 11kHz sample
+rate. Although this saves us processing overhead, the main goal was to 'focus' the noise reduction
+algorithms to process just the audio spectrum (0-5.5kHz), rather than trying to process the whole
+CD quality spectrum (0-22kHz), if we'd not decimated the native 44kHz sample rate.
 
 ### Display
 
@@ -220,6 +220,15 @@ dismissed. No point duplicating work.
 
 All submissions should come via Github pull requests. Requests, bugs etc. should be reported via
 Github issues.
+
+## Version History
+
+This section details the version 'releases', and what changed.
+
+| Version | Date       | Changes |
+| ------- | ---------- | ------- |
+| v1.0    | 2020-02-10 | Initial release |
+| v1.1    | 2020-02-16 | Normalise FIRs. Decimate audio x4 |
 
 [1]: https://github.com/DD4WH/Teensy-ConvolutionSDR "Teensy-ConvolutionSDR"
 [2]: https://github.com/df8oe/UHSDR "UHSDR"

--- a/global.h
+++ b/global.h
@@ -19,8 +19,9 @@
 
 #define BUFFER_SIZE 128
 
-// Run with no decimation, at 44.1KHz..
-#define DF 1
+// Decimate down to 11kHz - see if that helps the NR systems perform, as they will then not be trying
+// to operate on the 5-20kHz data, which we never listen to anyway!
+#define DF 4
 
 #define FFT_L 512
 #define FFT_length FFT_L

--- a/global.h
+++ b/global.h
@@ -4,7 +4,7 @@
 #include <arm_math.h>
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 0
+#define VERSION_MINOR 1
 
 #define VERSION_UINT16 ((uint16_t)((VERSION_MAJOR<<8)|VERSION_MINOR))
 


### PR DESCRIPTION
Decimate the audio path x4 (from 44kHz down to 11kHz).
The main benefit is it allows some of the processing, like the noise reduction methods, that are based on 'slots' to have finer granularity when working on the audio spectrum. Previously they would process ~0-22kHz. Now they process ~0-5.5kHz - so, 4x the granularity of filter frequency bins.

An added benefit is the CPU overhead is also reduced. With Spectral, glitch and notch we were at ~20%. With decimation we are now at ~7%.