### PR TITLE
FIR: clipping: Fix FIR filters. Add clipping indicator

### DIFF
--- a/dynamicFilters.cpp
+++ b/dynamicFilters.cpp
@@ -275,41 +275,42 @@ void bandstop(short h[], const int &N, const int &WINDOW, const double &fc1, con
 
 //---------------------------------------------------------------
 void audioFilter(short h[], const int &N, const int &TYPE, const int &WINDOW, const double &fc1, const double &fc2) {
+  
   switch (TYPE) {
       case ID_LOWPASS:
-                  #ifdef DEBUG
+                  #if DEBUG
                       Serial.print("LowPass Freq:");
                       Serial.println(fc1);
                   #endif
-                  lowpass(h, N, WINDOW, fc1/44117);
+                  lowpass(h, N, WINDOW, fc1/AUDIO_SAMPLE_RATE_EXACT);
                   break;
       case ID_HIGHPASS:
-                  #ifdef DEBUG
+                  #if DEBUG
                       Serial.print("HiPass Freq:");
                       Serial.println(fc1);
                   #endif
-                  highpass(h, N, WINDOW, fc1/44117);
+                  highpass(h, N, WINDOW, fc1/AUDIO_SAMPLE_RATE_EXACT);
                   break;
       case ID_BANDPASS:
-                  #ifdef DEBUG
+                  #if DEBUG
                       Serial.print("BandPass LFreq:");
                       Serial.print(fc1);
                       Serial.print(" HFreq:");
                       Serial.println(fc2);
                   #endif
-                  bandpass(h, N, WINDOW, fc1/44117, fc2/44117);
+                  bandpass(h, N, WINDOW, fc1/AUDIO_SAMPLE_RATE_EXACT, fc2/AUDIO_SAMPLE_RATE_EXACT);
                   break;
       case ID_BANDSTOP:
-                  #ifdef DEBUG
+                  #if DEBUG
                       Serial.print("Bandstop LFreq:");
                       Serial.print(fc1);
                       Serial.print(" HFreq:");
                       Serial.println(fc2);
                   #endif
-                  bandstop(h, N, WINDOW, fc1/44117, fc2/44117);
+                  bandstop(h, N, WINDOW, fc1/AUDIO_SAMPLE_RATE_EXACT, fc2/AUDIO_SAMPLE_RATE_EXACT);
                   break;
       default:
-                  #ifdef DEBUG
+                  #if DEBUG
                       Serial.println("Unknown");    
                   #endif
                   break;
@@ -329,15 +330,19 @@ float32_t getFilterGain(int16_t *coeffs, int ncoeffs, float32_t frequency, float
   float32_t gain = 0.0;
   float32_t f = frequency / samplerate;
 
+  if (DEBUG) Serial.printf("getFilterGain(ncoeff: %d, f:%f, rate:%f\n", ncoeffs, frequency, samplerate);
+
   for(int i=0; i<ncoeffs; i++ ) {
     float32_t c = cos(2.0 * M_PI * f * i);
     float32_t s = sin(2.0 * M_PI * f * i);
 
-    cgain += ((float32_t)coeffs[i]/32768.0) * c;
-    sgain += ((float32_t)coeffs[i]/32768.0) * s;
+    cgain += (((float32_t)coeffs[i])/32768.0) * c;
+    sgain += (((float32_t)coeffs[i])/32768.0) * s;
   }
 
   gain = (cgain*cgain) + (sgain*sgain);
+
+  if (DEBUG) Serial.printf(" Gain: %fhz, %f sample: %f gain\n", frequency, samplerate, sqrt(gain));
 
   //FIXME - we probably should limit the gain returned somewhere - possibly here.
   return (sqrt(gain));

--- a/global.cpp
+++ b/global.cpp
@@ -24,32 +24,6 @@ float32_t NR_alpha = 0.95; // default 0.99 --> range 0.98 - 0.9999; 0.95 acts mu
 float32_t DMAMEM NR_last_iFFT_result [NR_FFT_L / 2];
 float32_t DMAMEM NR_Gts[NR_FFT_L / 2][2]; // time smoothed gain factors (current and last) for each of the 128 bins
 
-uint8_t SAMPLE_RATE =            SAMPLE_RATE_44K;
-uint8_t LAST_SAMPLE_RATE =       SAMPLE_RATE_44K;
-
-const SR_Descriptor SR [18] =
-{ // x_factor, x_offset and f1 to f4 are NOT USED ANYMORE !!!
-  //   SR_n , rate, text, f1, f2, f3, f4, x_factor = pixels per f1 kHz in spectrum display
-  {  SAMPLE_RATE_8K, 8000,  "  8k", " 1", " 2", " 3", " 4", 64.0, 11}, // not OK
-  {  SAMPLE_RATE_11K, 11025, " 11k", " 1", " 2", " 3", " 4", 43.1, 17}, // not OK
-  {  SAMPLE_RATE_16K, 16000, " 16k",  " 4", " 4", " 8", "12", 64.0, 1}, // OK
-  {  SAMPLE_RATE_22K, 22050, " 22k",  " 5", " 5", "10", "15", 58.05, 6}, // OK
-  {  SAMPLE_RATE_32K, 32000,  " 32k", " 5", " 5", "10", "15", 40.0, 24}, // OK, one more indicator?
-  {  SAMPLE_RATE_44K, 44100,  " 44k", "10", "10", "20", "30", 58.05, 6}, // OK
-  {  SAMPLE_RATE_48K, 48000,  " 48k", "10", "10", "20", "30", 53.33, 11}, // OK
-  {  SAMPLE_RATE_50K, 50223,  " 50k", "10", "10", "20", "30", 53.33, 11}, // NOT OK
-  {  SAMPLE_RATE_88K, 88200,  " 88k", "20", "20", "40", "60", 58.05, 6}, // OK
-  {  SAMPLE_RATE_96K, 96000,  " 96k", "20", "20", "40", "60", 53.33, 12}, // OK
-  {  SAMPLE_RATE_100K, 100000,  "100k", "20", "20", "40", "60", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_101K, 100466,  "101k", "20", "20", "40", "60", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_176K, 176400,  "176k", "40", "40", "80", "120", 58.05, 6}, // OK
-  {  SAMPLE_RATE_192K, 192000,  "192k", "40", "40", "80", "120", 53.33, 12}, // not OK
-  {  SAMPLE_RATE_234K, 234375,  "234k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_256K, 256000,  "256k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_281K, 281000,  "281k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_353K, 352800,  "353k", "40", "40", "80", "120", 53.33, 12} // NOT OK
-};
-
 int nr_mode = NR_MODE_SPECTRAL;
 
 // Is the menu active, or should we 'display' our status and decoder output etc.

--- a/global.h
+++ b/global.h
@@ -4,7 +4,7 @@
 #include <arm_math.h>
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 1
+#define VERSION_MINOR 2
 
 #define VERSION_UINT16 ((uint16_t)((VERSION_MAJOR<<8)|VERSION_MINOR))
 
@@ -16,8 +16,12 @@
 #define VERSION_STRING STR(VERSION_MAJOR) "." STR(VERSION_MINOR)
 
 //#define DEBUG 1 //Enable to get serial port output
+#define DEBUG 0 //No debug output
 
 #define BUFFER_SIZE 128
+
+//this is the raw hardware rate, before decimation
+#define SAMPLE_RATE ((float32_t)AUDIO_SAMPLE_RATE_EXACT)
 
 // Decimate down to 11kHz - see if that helps the NR systems perform, as they will then not be trying
 // to operate on the 5-20kHz data, which we never listen to anyway!
@@ -59,45 +63,6 @@ extern float32_t DMAMEM NR_FFT_buffer [512] __attribute__ ((aligned (4)));
 extern float32_t NR_alpha;
 extern float32_t DMAMEM NR_last_iFFT_result [NR_FFT_L / 2];
 extern float32_t DMAMEM NR_Gts[NR_FFT_L / 2][2]; // time smoothed gain factors (current and last) for each of the 128 bins
-
-#define SAMPLE_RATE_MIN               6
-#define SAMPLE_RATE_8K                0
-#define SAMPLE_RATE_11K               1
-#define SAMPLE_RATE_16K               2
-#define SAMPLE_RATE_22K               3
-#define SAMPLE_RATE_32K               4
-#define SAMPLE_RATE_44K               5
-#define SAMPLE_RATE_48K               6
-#define SAMPLE_RATE_50K               7
-#define SAMPLE_RATE_88K               8
-#define SAMPLE_RATE_96K               9
-#define SAMPLE_RATE_100K              10
-#define SAMPLE_RATE_101K              11
-#define SAMPLE_RATE_176K              12
-#define SAMPLE_RATE_192K              13
-#define SAMPLE_RATE_234K              14
-#define SAMPLE_RATE_256K              15
-#define SAMPLE_RATE_281K              16 // ??
-#define SAMPLE_RATE_353K              17 // does not work !
-#define SAMPLE_RATE_MAX               15
-
-extern uint8_t SAMPLE_RATE;
-extern uint8_t LAST_SAMPLE_RATE;
-
-typedef struct SR_Descriptor
-{
-  const uint8_t SR_n;
-  const uint32_t rate;
-  const char* const text;
-  const char* const f1;
-  const char* const f2;
-  const char* const f3;
-  const char* const f4;
-  const float32_t x_factor;
-  const uint8_t x_offset;
-} SR_Desc;
-
-extern const SR_Descriptor SR [18];
 
 // global decoder stuff
 #define DECODER_OFF 0
@@ -146,6 +111,7 @@ extern float32_t agc_sg5k_decay;
 
 // From the main loop
 extern float32_t input_peak_acc;
+extern bool input_peak_clipped;
 
 //Display our output (or, is the menu active...)
 extern bool display;

--- a/lcd.cpp
+++ b/lcd.cpp
@@ -222,6 +222,10 @@ CPU is updated in the main loop.
   if (invol == 0 ) buf[0] = ' ';
   else buf[0] = invol;
 
+  //And then, if we clipped on input, overwrite with a *splat* char to try and make
+  // it visually obvious.
+  if (input_peak_clipped) buf[0] = '!';
+
   if (nr_mode != NR_MODE_COMPLETE_BYPASS ) {
     //Filter mode
     switch (current_filter_mode) {

--- a/nr_kim.cpp
+++ b/nr_kim.cpp
@@ -5,72 +5,6 @@
 #include "global.h"
 #include "nr_kim.h"
 
-//global #define NR_FFT_L    256
-
-#if 0 //global
-#define SAMPLE_RATE_MIN               6
-#define SAMPLE_RATE_8K                0
-#define SAMPLE_RATE_11K               1
-#define SAMPLE_RATE_16K               2
-#define SAMPLE_RATE_22K               3
-#define SAMPLE_RATE_32K               4
-#define SAMPLE_RATE_44K               5
-#define SAMPLE_RATE_48K               6
-#define SAMPLE_RATE_50K               7
-#define SAMPLE_RATE_88K               8
-#define SAMPLE_RATE_96K               9
-#define SAMPLE_RATE_100K              10
-#define SAMPLE_RATE_101K              11
-#define SAMPLE_RATE_176K              12
-#define SAMPLE_RATE_192K              13
-#define SAMPLE_RATE_234K              14
-#define SAMPLE_RATE_256K              15
-#define SAMPLE_RATE_281K              16 // ??
-#define SAMPLE_RATE_353K              17 // does not work !
-#define SAMPLE_RATE_MAX               15
-
-//uint8_t sr =                     SAMPLE_RATE_96K;
-uint8_t SAMPLE_RATE =            SAMPLE_RATE_44K;
-uint8_t LAST_SAMPLE_RATE =       SAMPLE_RATE_44K;
-
-typedef struct SR_Descriptor
-{
-  const uint8_t SR_n;
-  const uint32_t rate;
-  const char* const text;
-  const char* const f1;
-  const char* const f2;
-  const char* const f3;
-  const char* const f4;
-  const float32_t x_factor;
-  const uint8_t x_offset;
-} SR_Desc;
-
-
-const SR_Descriptor SR [18] =
-{ // x_factor, x_offset and f1 to f4 are NOT USED ANYMORE !!!
-  //   SR_n , rate, text, f1, f2, f3, f4, x_factor = pixels per f1 kHz in spectrum display
-  {  SAMPLE_RATE_8K, 8000,  "  8k", " 1", " 2", " 3", " 4", 64.0, 11}, // not OK
-  {  SAMPLE_RATE_11K, 11025, " 11k", " 1", " 2", " 3", " 4", 43.1, 17}, // not OK
-  {  SAMPLE_RATE_16K, 16000, " 16k",  " 4", " 4", " 8", "12", 64.0, 1}, // OK
-  {  SAMPLE_RATE_22K, 22050, " 22k",  " 5", " 5", "10", "15", 58.05, 6}, // OK
-  {  SAMPLE_RATE_32K, 32000,  " 32k", " 5", " 5", "10", "15", 40.0, 24}, // OK, one more indicator?
-  {  SAMPLE_RATE_44K, 44100,  " 44k", "10", "10", "20", "30", 58.05, 6}, // OK
-  {  SAMPLE_RATE_48K, 48000,  " 48k", "10", "10", "20", "30", 53.33, 11}, // OK
-  {  SAMPLE_RATE_50K, 50223,  " 50k", "10", "10", "20", "30", 53.33, 11}, // NOT OK
-  {  SAMPLE_RATE_88K, 88200,  " 88k", "20", "20", "40", "60", 58.05, 6}, // OK
-  {  SAMPLE_RATE_96K, 96000,  " 96k", "20", "20", "40", "60", 53.33, 12}, // OK
-  {  SAMPLE_RATE_100K, 100000,  "100k", "20", "20", "40", "60", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_101K, 100466,  "101k", "20", "20", "40", "60", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_176K, 176400,  "176k", "40", "40", "80", "120", 58.05, 6}, // OK
-  {  SAMPLE_RATE_192K, 192000,  "192k", "40", "40", "80", "120", 53.33, 12}, // not OK
-  {  SAMPLE_RATE_234K, 234375,  "234k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_256K, 256000,  "256k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_281K, 281000,  "281k", "40", "40", "80", "120", 53.33, 12}, // NOT OK
-  {  SAMPLE_RATE_353K, 352800,  "353k", "40", "40", "80", "120", 53.33, 12} // NOT OK
-};
-#endif  // global
-
 //global float32_t DMAMEM NR_FFT_buffer [512] __attribute__ ((aligned (4)));
 //global const static arm_cfft_instance_f32 *NR_FFT;
 
@@ -166,9 +100,9 @@ void nr_kim()
   lf_freq = 100;
   uf_freq = 3600;
 
-  // / rate DF SR[SAMPLE_RATE].rate/DF
-  lf_freq /= ((SR[SAMPLE_RATE].rate / DF) / NR_FFT_L); // bin BW is 46.9Hz [12000Hz / 256 bins] @96kHz
-  uf_freq /= ((SR[SAMPLE_RATE].rate / DF) / NR_FFT_L);
+  //Our sample rate is currently fixed - no need to use a lookup table.
+  lf_freq /= (SAMPLE_RATE / DF) / NR_FFT_L;
+  uf_freq /= (SAMPLE_RATE / DF) / NR_FFT_L;
 
   VAD_low = (int)lf_freq;
   VAD_high = (int)uf_freq;
@@ -334,7 +268,7 @@ void nr_kim()
       }
     }
 
-#ifdef DEBUG
+#if DEBUG
     // for debugging
     for (int bindx = 0; bindx < NR_FFT_L / 2; bindx++)
     {
@@ -376,7 +310,7 @@ void nr_kim()
     // NR_G is always positive, however often 0.0
 
     // for debugging
-#ifdef DEBUG
+#if DEBUG
     for (int bindx = 0; bindx < NR_FFT_L / 2; bindx++)
     {
       Serial.print((NR_Gts[bindx][0]), 6);
@@ -405,7 +339,7 @@ void nr_kim()
     //          NR_G_bin_m_1 = NR_Gts[NR_FFT_L / 2 - 1][0];
 
     // for debugging
-#ifdef DEBUG
+#if DEBUG
     for (int bindx = 0; bindx < NR_FFT_L / 2; bindx++)
     {
       Serial.print((NR_G[bindx]), 6);
@@ -425,7 +359,7 @@ void nr_kim()
     }
 
     // DEBUG
-#ifdef DEBUG
+#if DEBUG
     for (int bindx = 20; bindx < 21; bindx++)
     {
       Serial.println("************************************************");

--- a/spectral.cpp
+++ b/spectral.cpp
@@ -208,9 +208,9 @@ void spectral_noise_reduction (void)
   }
 #endif
 
-  // / rate DF SR[SAMPLE_RATE].rate/DF
-  lf_freq /= ((SR[SAMPLE_RATE].rate / DF) / NR_FFT_L); // bin BW is 46.9Hz [12000Hz / 256 bins] @96kHz
-  uf_freq /= ((SR[SAMPLE_RATE].rate / DF) / NR_FFT_L);
+  //Our sample rate is fixed...
+  lf_freq /= (SAMPLE_RATE / DF) / NR_FFT_L;
+  uf_freq /= (SAMPLE_RATE / DF) / NR_FFT_L;
 
   // Frank DD4WH & Michael DL2FW, November 2017
   // NOISE REDUCTION BASED ON SPECTRAL SUBTRACTION


### PR DESCRIPTION
When adding the 'FIR filter normalisation' for v1.2, it looks like
I messed up, and made things worse. The primary 'visible' results
from this were:
 - it was very easy to clip the input audio levels, which then gave a
   nasty output
 - the morse decoders were struggling a lot more detecting tones.

The core issue was some mismash of inherited code that meant we ended
up with two notions of 'SAMPLE_RATE', and the wrong one (an index,
not a value) ended up being used for the FIR evaluation, thus
breaking it. Fix that by ensuring we now only have one idea of
SAMPLE_RATE.

Whilst there, it seemed obvious that we already measured the input
volume level with a peak meter, so why not use that to try and give
a clear indication when we were clipping the input. Now when a clipped
input is detected (too loud!), we show a '!' in the input volume slot
for 0.5s to make it clear the input is too high.

Ultimately:
 - FIR filters are now better, so clipping reduced
 - CW decoders seem back to detecting tones better
 - Visual clip indicator should help identify why clipping is happenning.

Mark this as release v1.2, as this is a reasonaly important 'fix' on the
quality front.

Signed-off-by: Graham Whaley <graham.whaley@gmail.com>