### PR TITLE
Decode '=' in CW. Improve menu slot name edits

### DIFF
--- a/DSPham.ino
+++ b/DSPham.ino
@@ -432,24 +432,31 @@ void loop() {
           float32_t freq = noteFreq.read();
           int freqdiff = (int)freq - morse_frequency;
 
-          if ( abs(freqdiff) < morse_frequency/10 ) {
-            //Tone pretty close
-            lcd.createChar(7, morsechar2);  //'><'
-          } else {
-            if (freqdiff < 0 ) {
-              //Tone too low
-              if (freqdiff < -(morse_frequency/2) ) {
-                lcd.createChar(7, morsechar0);  //'<<'
-              } else {
-                lcd.createChar(7, morsechar1);  //'<'
-              }
+          //Accessing lcd.createChar() changes the internal address counter (AC) of the
+          //lcd module, which then changes the cursor position (if active), which can mess
+          //up the menu display. If we are in the menu system, do not access the lcd, at all.
+          if (display) {
+            //We could be more efficient and access the lcd interface less if we cache the last
+            //state we were in and only update when it changes.
+            if ( abs(freqdiff) < morse_frequency/10 ) {
+              //Tone pretty close
+              lcd.createChar(7, morsechar2);  //'><'
             } else {
-              //Tone too high
-              if (freqdiff > morse_frequency/2 ) {
-                lcd.createChar(7, morsechar3);  //'>>'
+              if (freqdiff < 0 ) {
+                //Tone too low
+                if (freqdiff < -(morse_frequency/2) ) {
+                  lcd.createChar(7, morsechar0);  //'<<'
+                } else {
+                  lcd.createChar(7, morsechar1);  //'<'
+                }
               } else {
-                lcd.createChar(7, morsechar4);  //'>'
-              }         
+                //Tone too high
+                if (freqdiff > morse_frequency/2 ) {
+                  lcd.createChar(7, morsechar3);  //'>>'
+                } else {
+                  lcd.createChar(7, morsechar4);  //'>'
+                }
+              }
             }
           }
           //Char is printed in the global lcd update routine

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ the [Release page][22].
 | v1.0    | 2021-02-10 | Initial release |
 | v1.1    | 2021-02-16 | Normalise FIRs. Decimate audio x4 |
 | v1.2    | 2021-03-16 | Fix FIR normalise bug. Add input clip indicator |
+| v1.3    | 2021-11-08 | CW decode enhance. Menu name slot edit enhance |
 
 ## Samples
 

--- a/global.h
+++ b/global.h
@@ -4,7 +4,7 @@
 #include <arm_math.h>
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 2
+#define VERSION_MINOR 3
 
 #define VERSION_UINT16 ((uint16_t)((VERSION_MAJOR<<8)|VERSION_MINOR))
 

--- a/k4icy.cpp
+++ b/k4icy.cpp
@@ -430,7 +430,7 @@ void k4icy_keyUp()
 /// Secret Decoder Ring ///////////////////////////////////
 void morseDecode()
 {                               //  Here, we check the collected elements against our list to decode for the matching character
-  decodeChar = '?';             //Unkown char. (changed from 0x7 special char in original code, as we already use that)
+  decodeChar = 0xff;             //Unkown char. (changed from 0x7 special char in original code, as we already use that) 0xff is a solid 'block' on 2x16 charset
   decodeProSign = "";
 
   //Serial.println(elementSequence);

--- a/k4icy.cpp
+++ b/k4icy.cpp
@@ -581,7 +581,9 @@ void morseDecode()
   if (strcmp(elementSequence, "-.-.-.") == 0) {
     decodeChar = 59;
   }                             // ;
-  //if (strcmp(elementSequence,"-...-") == 0)   { decodeChar = 61; }  // = (Pause, BT)
+  if (strcmp(elementSequence,"-...-") == 0) {
+    decodeChar = 61;
+  }                             // = (Pause, BT)
   if (strcmp(elementSequence, "..--..") == 0) {
     decodeChar = 63;
   }                             // ?

--- a/menu.cpp
+++ b/menu.cpp
@@ -260,7 +260,7 @@ MENU(VolumeMenu, "Volume", Menu::doNothing, Menu::noEvent, Menu::wrapStyle
 
 int active_settings_slot = 0;
 //Only allow nums and lower case to reduce scrolling/choice
-char* constMEM alphaNum MEMMODE="0123456789abcdefghijklmnopqrstuvwxyz";
+char* constMEM alphaNum MEMMODE="0123456789abcdefghijklmnopqrstuvwxyz ";
 char* constMEM alphaNumMask[] MEMMODE={alphaNum};
 char active_slot_name[]="0123";   //Name of the currently selected editing slot
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -334,7 +334,6 @@ void load_specific_settings(uint8_t slot) {
 void saveSetting(int slot) {
   struct settings *s = &live_settings.slots[slot];
   int eeoffset;
-  char name[4];
 
   //Just blindly copy the whole slot to the eeprom - initialised or not..  
   s->filter.lowfreq = filterList[current_filter_mode].freqLow;
@@ -362,6 +361,9 @@ void saveSetting(int slot) {
   
   s->decoder.decoder_mode = decoder_mode;
 
+  //The name field should already be filled out correctly from either loading the defaults
+  //or from a previous call to setSettingsName()
+
   eeoffset = offsetof(eedata, slots);
   eeoffset += sizeof(struct settings) * slot; //user data at front of eeprom. Slots indexed from 0
 
@@ -378,7 +380,7 @@ void saveSetting(int slot) {
 void getSettingsName(int slot, char *cp) {
   char *p = live_settings.slots[slot].name;
     
-  for (int i=0; i<4; i++) cp[i] = p[i];
+  for (int i=0; i<SETTING_NAME_LENGTH; i++) cp[i] = p[i];
 }
 
 //Set the name in the live settings, but do not write it to the eeprom
@@ -387,10 +389,8 @@ void setSettingsName(int slot, char *cp) {
   struct settings *s = &live_settings.slots[slot];  
 
   //Set the name in the live data
-  live_settings.slots[slot].name[0] = cp[0];
-  live_settings.slots[slot].name[1] = cp[1];
-  live_settings.slots[slot].name[2] = cp[2];
-  live_settings.slots[slot].name[3] = cp[3];
+  for (int i=0; i<SETTING_NAME_LENGTH; i++)
+    live_settings.slots[slot].name[i] = cp[i];
 }
 
 void init_settings(void) {

--- a/settings.h
+++ b/settings.h
@@ -41,9 +41,11 @@ struct decoder_settings {
 	uint8_t decoder_mode;	//off or which?
 };
 
-	
+
+#define SETTING_NAME_LENGTH	4
+
 struct settings {
-  char name[4];
+	char name[SETTING_NAME_LENGTH];
 	struct filter_settings filter;
 	struct nb_settings nb;
 	struct autonotch_settings autonotch;


### PR DESCRIPTION
Enable the decoding of '=' in the k4icy CW decoder.
Fix the problem where the cursor would move around whilst trying to edit the slot names.